### PR TITLE
fix: fix the null farm name when adding a farm

### DIFF
--- a/src/components/farms/FarmForm.jsx
+++ b/src/components/farms/FarmForm.jsx
@@ -58,7 +58,7 @@ function FarmForm() {
     } else {
       try {
         await postData("/farm/farms/", finalData);  // fix {data} is still null after post
-        //toast.success("La granja "+ data.name+ " fue añadida correctamente");
+        toast.success("La granja "+ finalData.name+ " fue añadida correctamente");
         navigate("/farm/farms/");
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
Issue: When adding a new farm, the `data.name` was not displayed correctly. This issue was caused by the variable `data` not being defined; instead, `finalData` was used.

Solution: Replaced the undefined `data` variable with `finalData`, and accessed the name property using `finalData.name`.

Outcome: This fix resolves the bug, allowing the message to display correctly and ensuring proper redirection to the farm list page.